### PR TITLE
Ensuring adding google id and key to strings.xml always works

### DIFF
--- a/hooks/android/copy-google-services.js
+++ b/hooks/android/copy-google-services.js
@@ -43,24 +43,24 @@ module.exports = function (context) {
           var json = JSON.parse(contents);
           var strings = fs.readFileSync(path.join(androidFolder, "res/values/strings.xml")).toString();
 
-          // replace value
-          strings = strings.replace(new RegExp('<string name="google_app_id">[^<]+?</string>', "i"), '<string name="google_app_id">' + json.client[0].client_info.mobilesdk_app_id + '</string>');
+          // strip any existing value
+          strings = strings.replace(new RegExp('<string name="google_app_id">[^<]+?</string>', "ig"), '');
 
-          // replace value
-          strings = strings.replace(new RegExp('<string name="google_api_key">[^<]+?</string>', "i"), '<string name="google_api_key">' + json.client[0].api_key[0].current_key + '</string>');
+          // strip any existing value
+          strings = strings.replace(new RegExp('<string name="google_api_key">[^<]+?</string>', "ig"), '');
 
           // strip empty lines
           strings = strings.replace(new RegExp('(\r\n|\n|\r)[ \t]*(\r\n|\n|\r)', "gm"), '$1');
 
           // add value if it didn't exist
           if (strings.indexOf('<string name="google_app_id">') == -1) {
-            strings = strings.replace(new RegExp('</resources>', "i"), '    <string name="google_app_id">' + json.client[0].client_info.mobilesdk_app_id + '</string>\n</resources>');
+              strings = strings.replace(new RegExp('</resources>', "i"), '    <string name="google_app_id">' + json.client[0].client_info.mobilesdk_app_id + '</string>\n</resources>');
           }
           // add value if it didn't exist
           if (strings.indexOf('<string name="google_api_key">') == -1) {
-            strings = strings.replace(new RegExp('</resources>', "i"), '    <string name="google_api_key">' + json.client[0].api_key[0].current_key + '</string>\n</resources>');
+              strings = strings.replace(new RegExp('</resources>', "i"), '    <string name="google_api_key">' + json.client[0].api_key[0].current_key + '</string>\n</resources>');
           }
-          
+
           fs.writeFileSync(path.join(androidFolder, "res/values/strings.xml"), strings);
         } catch(err) {
           logMe(err);

--- a/hooks/android/copy-google-services.js
+++ b/hooks/android/copy-google-services.js
@@ -43,15 +43,24 @@ module.exports = function (context) {
           var json = JSON.parse(contents);
           var strings = fs.readFileSync(path.join(androidFolder, "res/values/strings.xml")).toString();
 
-          // strip non-default value
+          // replace value
           strings = strings.replace(new RegExp('<string name="google_app_id">[^<]+?</string>', "i"), '<string name="google_app_id">' + json.client[0].client_info.mobilesdk_app_id + '</string>');
 
-          // strip non-default value
+          // replace value
           strings = strings.replace(new RegExp('<string name="google_api_key">[^<]+?</string>', "i"), '<string name="google_api_key">' + json.client[0].api_key[0].current_key + '</string>');
 
           // strip empty lines
           strings = strings.replace(new RegExp('(\r\n|\n|\r)[ \t]*(\r\n|\n|\r)', "gm"), '$1');
 
+          // add value if it didn't exist
+          if (strings.indexOf('<string name="google_app_id">') == -1) {
+            strings = strings.replace(new RegExp('</resources>', "i"), '    <string name="google_app_id">' + json.client[0].client_info.mobilesdk_app_id + '</string>\n</resources>');
+          }
+          // add value if it didn't exist
+          if (strings.indexOf('<string name="google_api_key">') == -1) {
+            strings = strings.replace(new RegExp('</resources>', "i"), '    <string name="google_api_key">' + json.client[0].api_key[0].current_key + '</string>\n</resources>');
+          }
+          
           fs.writeFileSync(path.join(androidFolder, "res/values/strings.xml"), strings);
         } catch(err) {
           logMe(err);


### PR DESCRIPTION
The latest version in master works for the first build, but errors on the 2nd build, as it ends up having 2 entries for google_app_id and google_api_key in strings.xml. This fix ensures it always ends up with the right values.